### PR TITLE
Fix qp quadratic objective

### DIFF
--- a/hilo_mpc/modules/optimizer.py
+++ b/hilo_mpc/modules/optimizer.py
@@ -770,6 +770,32 @@ class LinearProgram(Optimizer):
 class QuadraticProgram(LinearProgram):
     """"""
 
+    def __init__(
+            self,
+            id: Optional[str] = None,
+            name: Optional[str] = None,
+            solver: Optional[str] = None,
+            solver_options: Optional[dict[str, Union[str, Numeric]]] = None,
+            plot_backend: Optional[str] = None
+    ) -> None:
+        """Constructor method"""
+        if solver is None:
+            # 'clp' (inherited LP default) only handles linear objectives;
+            # 'osqp' supports quadratic objectives natively.
+            solver = 'osqp'
+        super().__init__(id=id, name=name, solver=solver, solver_options=solver_options, plot_backend=plot_backend)
+
+    def setup(self, **kwargs):
+        """
+        Set up the QP. Unlike LP, quadratic objectives are allowed.
+
+        :param kwargs:
+        :return:
+        """
+        # Skip LP's linearity check so that quadratic objectives are accepted;
+        # ca.qpsol with osqp handles them natively.
+        Optimizer.setup(self, interface=ca.qpsol, **kwargs)
+
 
 class NonlinearProgram(Optimizer):
     """

--- a/hilo_mpc/modules/optimizer.py
+++ b/hilo_mpc/modules/optimizer.py
@@ -670,11 +670,13 @@ class Optimizer(Base, metaclass=ABCMeta):
         p = kwargs.get('p')
         if p is not None:
             self._solution.add('p', p)
-        elif self._solution.get_by_id('p').is_empty():
-            warnings.warn(f"No parameter values supplied. Setting them to 0. Execute "
-                          f"{self.__class__.__name__}.set_parameter_values(p) or supply them as a keyword argument to "
-                          f"{self.__class__.__name__}.solve(...) to set different parameter values.")
-            self.set_parameter_values(self._n_p * [0.])
+        elif self._n_p > 0:
+            p_val = self._solution.get_by_id('p')
+            if p_val is None or p_val.is_empty():
+                warnings.warn(f"No parameter values supplied. Setting them to 0. Execute "
+                              f"{self.__class__.__name__}.set_parameter_values(p) or supply them as a keyword argument to "
+                              f"{self.__class__.__name__}.solve(...) to set different parameter values.")
+                self.set_parameter_values(self._n_p * [0.])
 
         args = self._solution.get_function_args()
         args['lbx'] = self._lbx.values

--- a/tests/test_ANN.py
+++ b/tests/test_ANN.py
@@ -1,0 +1,259 @@
+import unittest
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from hilo_mpc import ANN, Layer
+
+try:
+    import torch
+    PYTORCH_AVAILABLE = True
+except ImportError:
+    PYTORCH_AVAILABLE = False
+
+requires_pytorch = unittest.skipUnless(PYTORCH_AVAILABLE, "PyTorch not installed")
+
+
+class TestLayerDense(unittest.TestCase):
+    """Tests for Dense layer creation and configuration"""
+
+    def test_dense_single_layer_default_activation(self):
+        """Dense layer with default activation (linear)"""
+        layer = Layer.dense(10)
+        self.assertEqual(len(layer), 10)
+        self.assertEqual(layer.activation, 'linear')
+
+    def test_dense_single_layer_sigmoid_activation(self):
+        """Dense layer with sigmoid activation"""
+        layer = Layer.dense(20, activation='sigmoid')
+        self.assertEqual(len(layer), 20)
+        self.assertEqual(layer.activation, 'sigmoid')
+
+    def test_dense_single_layer_relu_activation(self):
+        """Dense layer with relu activation"""
+        layer = Layer.dense(15, activation='relu')
+        self.assertEqual(len(layer), 15)
+        self.assertEqual(layer.activation, 'relu')
+
+    def test_dense_single_layer_tanh_activation(self):
+        """Dense layer with tanh activation"""
+        layer = Layer.dense(8, activation='tanh')
+        self.assertEqual(len(layer), 8)
+        self.assertEqual(layer.activation, 'tanh')
+
+    def test_dense_multiple_layers(self):
+        """Dense with list of nodes returns list of layers"""
+        layers = Layer.dense([10, 20, 10], activation='sigmoid')
+        self.assertIsInstance(layers, list)
+        self.assertEqual(len(layers), 3)
+        self.assertEqual(len(layers[0]), 10)
+        self.assertEqual(len(layers[1]), 20)
+        self.assertEqual(len(layers[2]), 10)
+
+    def test_dense_multiple_layers_different_activations(self):
+        """Dense with list of nodes and list of activations"""
+        layers = Layer.dense([10, 20], activation=['relu', 'sigmoid'])
+        self.assertEqual(len(layers), 2)
+        self.assertEqual(layers[0].activation, 'relu')
+        self.assertEqual(layers[1].activation, 'sigmoid')
+
+    def test_dense_layer_type(self):
+        """Dense layer has type 'Dense'"""
+        layer = Layer.dense(10)
+        self.assertIsNotNone(layer.type)
+
+    def test_dense_layer_with_initializer(self):
+        """Dense layer with explicit initializer"""
+        layer = Layer.dense(10, initializer='uniform')
+        self.assertIsNotNone(layer.initializer)
+        self.assertEqual(layer.initializer, 'uniform')
+
+    def test_dense_layer_activation_mismatch_raises(self):
+        """Mismatched nodes and activation list lengths raise ValueError"""
+        with self.assertRaises(ValueError):
+            Layer.dense([10, 20], activation=['relu', 'sigmoid', 'tanh'])
+
+    def test_dense_layer_initializer_mismatch_raises(self):
+        """Mismatched nodes and initializer list lengths raise ValueError"""
+        with self.assertRaises(ValueError):
+            Layer.dense([10, 20], initializer=['uniform', 'normal', 'zeros'])
+
+
+class TestLayerDropout(unittest.TestCase):
+    """Tests for Dropout layer creation"""
+
+    def test_dropout_layer_creation(self):
+        """Dropout layer can be created"""
+        layer = Layer.dropout(0.2)
+        self.assertIsNotNone(layer)
+
+    def test_dropout_layer_type(self):
+        """Dropout layer has type 'Dropout'"""
+        layer = Layer.dropout(0.2)
+        self.assertIsNotNone(layer.type)
+
+    def test_dropout_rate_stored(self):
+        """Dropout rate is correctly stored"""
+        layer = Layer.dropout(0.5)
+        self.assertIsNotNone(layer)
+
+
+class TestANNInitialization(unittest.TestCase):
+    """Tests for ANN class initialization"""
+
+    def test_ann_basic_initialization(self):
+        """ANN can be initialized with features and labels"""
+        ann = ANN(['x1', 'x2'], ['y1'])
+        self.assertIsNotNone(ann)
+
+    def test_ann_multiple_features_and_labels(self):
+        """ANN initializes with multiple features and labels"""
+        ann = ANN(['x1', 'x2', 'x3'], ['y1', 'y2'])
+        self.assertIsNotNone(ann)
+
+    def test_ann_default_backend_is_pytorch(self):
+        """ANN default backend is pytorch"""
+        ann = ANN(['x'], ['y'])
+        self.assertEqual(ann.backend, 'pytorch')
+
+    def test_ann_default_loss_is_mse(self):
+        """ANN default loss is mse"""
+        ann = ANN(['x'], ['y'])
+        self.assertEqual(ann.loss, 'mse')
+
+    def test_ann_default_optimizer_is_adam(self):
+        """ANN default optimizer is adam"""
+        ann = ANN(['x'], ['y'])
+        self.assertEqual(ann.optimizer, 'adam')
+
+    def test_ann_custom_learning_rate(self):
+        """ANN stores custom learning rate"""
+        ann = ANN(['x'], ['y'], learning_rate=0.01)
+        self.assertAlmostEqual(ann.learning_rate, 0.01)
+
+    def test_ann_custom_seed(self):
+        """ANN stores custom seed"""
+        ann = ANN(['x'], ['y'], seed=42)
+        self.assertEqual(ann.seed, 42)
+
+    def test_ann_features_count(self):
+        """ANN correctly reports number of features"""
+        ann = ANN(['x1', 'x2', 'x3'], ['y'])
+        self.assertEqual(ann.n_features, 3)
+
+    def test_ann_labels_count(self):
+        """ANN correctly reports number of labels"""
+        ann = ANN(['x'], ['y1', 'y2'])
+        self.assertEqual(ann.n_labels, 2)
+
+
+class TestANNLayerManagement(unittest.TestCase):
+    """Tests for ANN layer addition and management"""
+
+    def setUp(self):
+        self.ann = ANN(['x1', 'x2'], ['y1'])
+
+    def test_add_single_dense_layer(self):
+        """ANN can add a single Dense layer"""
+        self.ann.add_layers(Layer.dense(10, activation='sigmoid'))
+        self.assertEqual(self.ann.depth, 1)
+
+    def test_add_multiple_dense_layers(self):
+        """ANN can add multiple Dense layers"""
+        self.ann.add_layers(Layer.dense(10, activation='sigmoid'))
+        self.ann.add_layers(Layer.dense(5, activation='relu'))
+        self.assertEqual(self.ann.depth, 2)
+
+    def test_add_layer_list(self):
+        """ANN can add a list of layers at once"""
+        layers = Layer.dense([10, 5], activation='sigmoid')
+        self.ann.add_layers(layers)
+        self.assertEqual(self.ann.depth, 2)
+
+    def test_ann_shape_with_layers(self):
+        """ANN shape reflects features, hidden nodes, and labels"""
+        self.ann.add_layers(Layer.dense(10, activation='sigmoid'))
+        shape = self.ann.shape
+        # shape should be (n_features, hidden_nodes, n_labels)
+        self.assertEqual(shape[0], 2)   # n_features
+        self.assertEqual(shape[1], 10)  # hidden nodes
+        self.assertEqual(shape[2], 1)   # n_labels
+
+    def test_dropout_not_counted_in_depth(self):
+        """Dropout layers are not counted in depth"""
+        self.ann.add_layers(Layer.dense(10, activation='sigmoid'))
+        self.ann.add_layers(Layer.dropout(0.2))
+        self.ann.add_layers(Layer.dense(5, activation='sigmoid'))
+        # depth only counts Dense layers
+        self.assertEqual(self.ann.depth, 2)
+
+
+class TestANNTrainingAndPrediction(unittest.TestCase):
+    """Tests for ANN training and prediction with synthetic data"""
+
+    def setUp(self):
+        """Create a simple dataset for training"""
+        np.random.seed(0)
+        n = 50
+        x = np.random.randn(n, 2)
+        y = np.sin(x[:, 0:1]) + 0.1 * np.random.randn(n, 1)
+        self.df = pd.DataFrame(np.hstack([x, y]), columns=['x1', 'x2', 'y1'])
+
+    @requires_pytorch
+    def test_ann_training_completes(self):
+        """ANN training runs without error"""
+        ann = ANN(['x1', 'x2'], ['y1'])
+        ann.add_layers(Layer.dense(5, activation='sigmoid'))
+        ann.setup(save_tensorboard=False)
+        ann.add_data_set(self.df)
+        ann.train(1, 2, test_split=0.2, patience=100, verbose=0)
+
+    def test_ann_add_data_set(self):
+        """ANN correctly stores data set"""
+        ann = ANN(['x1', 'x2'], ['y1'])
+        ann.add_data_set(self.df)
+        self.assertEqual(len(ann._data_sets), 1)
+
+    def test_ann_data_set_wrong_feature_raises(self):
+        """ANN raises ValueError when data set missing required feature"""
+        ann = ANN(['x1', 'x2', 'missing_feature'], ['y1'])
+        with self.assertRaises(ValueError):
+            ann.add_data_set(self.df)
+
+    def test_ann_data_set_wrong_label_raises(self):
+        """ANN raises ValueError when data set missing required label"""
+        ann = ANN(['x1', 'x2'], ['y1', 'missing_label'])
+        with self.assertRaises(ValueError):
+            ann.add_data_set(self.df)
+
+    @requires_pytorch
+    def test_ann_casadi_graph_after_training(self):
+        """ANN can build CasADi graph after training"""
+        ann = ANN(['x1', 'x2'], ['y1'])
+        ann.add_layers(Layer.dense(5, activation='sigmoid'))
+        ann.setup(save_tensorboard=False)
+        ann.add_data_set(self.df)
+        ann.train(1, 2, test_split=0.2, patience=100, verbose=0)
+        # Should not raise
+        ann.build_graph()
+        self.assertIsNotNone(ann._function)
+
+    @requires_pytorch
+    def test_ann_prediction_after_training(self):
+        """ANN produces output after training (via CasADi graph)"""
+        import casadi as ca
+        ann = ANN(['x1', 'x2'], ['y1'])
+        ann.add_layers(Layer.dense(5, activation='sigmoid'))
+        ann.setup(save_tensorboard=False)
+        ann.add_data_set(self.df)
+        ann.train(1, 2, test_split=0.2, patience=100, verbose=0)
+        ann.build_graph()
+        # Test that the function can be called with a sample input
+        x_test = ca.DM([0.5, -0.3])
+        result = ann._function(x_test)
+        self.assertEqual(result.size1(), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ANN.py
+++ b/tests/test_ANN.py
@@ -251,8 +251,10 @@ class TestANNTrainingAndPrediction(unittest.TestCase):
         ann.build_graph()
         # Test that the function can be called with a sample input
         x_test = ca.DM([0.5, -0.3])
+        # _function returns a tuple of CasADi DMs: (labels, hidden_layer_1, ...)
         result = ann._function(x_test)
-        self.assertEqual(result.size1(), 1)
+        labels = result[0]
+        self.assertEqual(labels.size1(), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_LMPC.py
+++ b/tests/test_LMPC.py
@@ -296,5 +296,151 @@ class TestSolvers(unittest.TestCase):
         mpc.optimize(x0=x0)
 
 
+class TestLMPCCostFunction(unittest.TestCase):
+    """Tests for LMPC cost function configurations"""
+
+    def setUp(self) -> None:
+        model = Model(plot_backend='bokeh', discrete=True)
+        Ts = 0.5
+        model.A = np.array([[1, Ts], [0, 1]])
+        model.B = np.array([[Ts ** 2 / 2], [Ts]])
+        model.setup(dt=Ts)
+        model.set_initial_conditions(x0=[1., 0.])
+        self.model = model
+        self.x0 = [1., 0.]
+
+    def test_lmpc_with_terminal_cost(self):
+        """LMPC with terminal cost (P matrix) sets up and optimizes without error"""
+        model = self.model
+        x0 = self.x0
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = 1
+        mpc.P = np.eye(2)  # Terminal cost matrix
+        mpc.horizon = 5
+        mpc.setup()
+        u = mpc.optimize(x0=x0)
+        self.assertIsNotNone(u)
+
+    def test_lmpc_q_matrix_stored(self):
+        """LMPC stores Q matrix correctly after setup"""
+        model = self.model
+        Q = 2. * np.eye(2)
+        mpc = LMPC(model)
+        mpc.Q = Q
+        mpc.R = 1
+        mpc.horizon = 5
+        mpc.setup()
+        np.testing.assert_allclose(mpc.Q, Q)
+
+    def test_lmpc_r_matrix_stored(self):
+        """LMPC stores R matrix correctly after setup"""
+        model = self.model
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = 0.5
+        mpc.horizon = 5
+        mpc.setup()
+        self.assertAlmostEqual(float(mpc.R), 0.5)
+
+
+class TestLMPCConstraints(unittest.TestCase):
+    """Tests for LMPC constraint configurations"""
+
+    def setUp(self) -> None:
+        model = Model(plot_backend='bokeh', discrete=True)
+        Ts = 0.5
+        model.A = np.array([[1, Ts], [0, 1]])
+        model.B = np.array([[Ts ** 2 / 2], [Ts]])
+        model.setup(dt=Ts)
+        model.set_initial_conditions(x0=[2., 0.])
+        self.model = model
+        self.x0 = [2., 0.]
+
+    def test_lmpc_box_constraints_respected(self):
+        """LMPC optimal input respects upper bound constraint"""
+        model = self.model
+        x0 = self.x0
+        u_ub = 0.5
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = 1
+        mpc.horizon = 10
+        mpc.set_box_constraints(x_lb=[-5, -5], x_ub=[5, 5], u_lb=[-u_ub], u_ub=[u_ub])
+        mpc.setup()
+        u = mpc.optimize(x0=x0)
+        self.assertLessEqual(abs(float(u[0])), u_ub + 1e-6)
+
+    def test_lmpc_no_constraints_setup(self):
+        """LMPC without box constraints sets up and runs"""
+        model = self.model
+        x0 = self.x0
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = 1
+        mpc.horizon = 5
+        mpc.setup()
+        u = mpc.optimize(x0=x0)
+        self.assertIsNotNone(u)
+
+    def test_lmpc_soft_constraints(self):
+        """LMPC with soft state constraints sets up without error"""
+        model = self.model
+        x0 = self.x0
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = 1
+        mpc.horizon = 5
+        mpc.set_box_constraints(x_lb=[-5, -5], x_ub=[5, 5], u_lb=[-2], u_ub=[2])
+        mpc.setup()
+        u = mpc.optimize(x0=x0)
+        self.assertIsNotNone(u)
+
+
+class TestLMPCHorizon(unittest.TestCase):
+    """Tests for LMPC prediction horizon configuration"""
+
+    def setUp(self) -> None:
+        model = Model(plot_backend='bokeh', discrete=True)
+        Ts = 0.5
+        model.A = np.array([[1, Ts], [0, 1]])
+        model.B = np.array([[Ts ** 2 / 2], [Ts]])
+        model.setup(dt=Ts)
+        model.set_initial_conditions(x0=[1., 0.])
+        self.model = model
+        self.x0 = [1., 0.]
+
+    def test_lmpc_short_horizon(self):
+        """LMPC with horizon=2 sets up and runs"""
+        model = self.model
+        x0 = self.x0
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = 1
+        mpc.horizon = 2
+        mpc.setup()
+        u = mpc.optimize(x0=x0)
+        self.assertIsNotNone(u)
+
+    def test_lmpc_long_horizon(self):
+        """LMPC with horizon=50 sets up and runs"""
+        model = self.model
+        x0 = self.x0
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = 1
+        mpc.horizon = 50
+        mpc.setup()
+        u = mpc.optimize(x0=x0)
+        self.assertIsNotNone(u)
+
+    def test_lmpc_horizon_stored(self):
+        """LMPC stores prediction horizon correctly"""
+        model = self.model
+        mpc = LMPC(model)
+        mpc.horizon = 15
+        self.assertEqual(mpc.horizon, 15)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_OCP.py
+++ b/tests/test_OCP.py
@@ -1,66 +1,99 @@
 import unittest
 
 import casadi as ca
+import numpy as np
 
 from hilo_mpc import SimpleControlLoop, Model, OCP
 
 
-class MyTestCase(unittest.TestCase):
+def _make_pendulum_model(dt=0.1):
+    """Helper: cart-pendulum model with two inputs"""
+    model = Model(plot_backend='bokeh')
+    M, m, l, g = 5., 1., 1., 9.81
+    x = model.set_dynamical_states('x', 'v', 'theta', 'omega')
+    model.set_measurements('yx', 'yv', 'ytheta', 'tomega')
+    model.set_measurement_equations([x[0], x[1], x[2], x[3]])
+    v = x[1]
+    theta = x[2]
+    omega = x[3]
+    F = model.set_inputs('F1', 'F2')
+    dx = v
+    dv = 1. / (M + m - m * ca.cos(theta)) * (m * g * ca.sin(theta) - m * l * ca.sin(theta) * omega ** 2 + F[0])
+    dtheta = omega
+    domega = 1. / l * (dv * ca.cos(theta) + g * ca.sin(theta)) + F[1]
+    model.set_equations(ode=[dx, dv, dtheta, domega])
+    model.setup(dt=dt)
+    return model
+
+
+class TestOCPSetup(unittest.TestCase):
     """"""
     def setUp(self) -> None:
-        """
+        self.model = _make_pendulum_model()
+        self.x0 = [2.5, 0., 0.1, 0.]
+        self.u0 = [0., 0.]
 
-        :return:
-        """
-        model = Model(plot_backend='bokeh')
-        # Constants
-        M = 5.
-        m = 1.
-        l = 1.
-        h = .5
-        g = 9.81
+    def test_ocp_type(self):
+        """OCP reports type 'OCP'"""
+        ocp = OCP(self.model)
+        self.assertEqual(ocp.type, 'OCP')
 
-        # States and algebraic variables
-        x = model.set_dynamical_states('x', 'v', 'theta', 'omega')
-        model.set_measurements('yx', 'yv', 'ytheta', 'tomega')
-        model.set_measurement_equations([x[0], x[1], x[2], x[3]])
-        # y = model.set_algebraic_variables(['y'])
-        v = x[1]
-        theta = x[2]
-        omega = x[3]
-        # Inputs
-        F = model.set_inputs('F1', 'F2')
+    def test_ocp_initialization(self):
+        """OCP can be instantiated with a model"""
+        ocp = OCP(self.model)
+        self.assertIsNotNone(ocp)
 
-        # ODE
-        dx = v
-        dv = 1. / (M + m - m * ca.cos(theta)) * (m * g * ca.sin(theta) - m * l * ca.sin(theta) * omega ** 2 + F[0])
-        dtheta = omega
-        domega = 1. / l * (dv * ca.cos(theta) + g * ca.sin(theta)) + F[1]
+    def test_ocp_horizon(self):
+        """OCP stores horizon length"""
+        ocp = OCP(self.model)
+        ocp.horizon = 20
+        self.assertEqual(ocp.horizon, 20)
 
-        model.set_equations(ode=[dx, dv, dtheta, domega])
+    def test_ocp_setup(self):
+        """OCP sets up without error when horizon and cost are provided"""
+        ocp = OCP(self.model)
+        ocp.quad_stage_cost.add_states(names=['v', 'theta'], ref=[0, 0], weights=[10, 5])
+        ocp.quad_stage_cost.add_inputs(names=['F1', 'F2'], weights=[0.1, 0.1])
+        ocp.horizon = 10
+        ocp.set_initial_guess(x_guess=self.x0, u_guess=self.u0)
+        ocp.setup()
+        self.assertTrue(ocp.is_setup())
 
-        # Initial conditions
-        x0 = [2.5, 0., 0.1, 0.]
-        u0 = [0., 0.]
+    def test_ocp_with_box_constraints(self):
+        """OCP setup succeeds with state and input box constraints"""
+        ocp = OCP(self.model)
+        ocp.quad_stage_cost.add_states(names=['v', 'theta'], ref=[0, 0], weights=[10, 5])
+        ocp.quad_stage_cost.add_inputs(names=['F1', 'F2'], weights=[0.1, 0.1])
+        ocp.horizon = 10
+        ocp.set_box_constraints(x_ub=[5, 10, 10, 10], x_lb=[-5, -10, -10, -10])
+        ocp.set_initial_guess(x_guess=self.x0, u_guess=self.u0)
+        ocp.setup()
+        self.assertTrue(ocp.is_setup())
 
-        # Create model and run simulation
-        dt = .1
-        model.setup(dt=dt)
+    def test_ocp_terminal_cost(self):
+        """OCP sets up with terminal cost without error"""
+        ocp = OCP(self.model)
+        ocp.quad_stage_cost.add_states(names=['v', 'theta'], ref=[0, 0], weights=[10, 5])
+        ocp.quad_terminal_cost.add_states(names=['v', 'theta'], ref=[0, 0], weights=[10, 5])
+        ocp.quad_stage_cost.add_inputs(names=['F1', 'F2'], weights=[0.1, 0.1])
+        ocp.horizon = 10
+        ocp.set_initial_guess(x_guess=self.x0, u_guess=self.u0)
+        ocp.setup()
+        self.assertTrue(ocp.is_setup())
 
-        self.model = model
-        self.dt = dt
-        self.x0 = x0
-        self.u0 = u0
+
+class TestOCPSolve(unittest.TestCase):
+    """"""
+    def setUp(self) -> None:
+        self.model = _make_pendulum_model()
+        self.x0 = [2.5, 0., 0.1, 0.]
+        self.u0 = [0., 0.]
 
     def test_ocp(self):
-        """
-        Test normal nonlinear MPC for using a pendulum model. This test checks the normal problem setup
-
-        :return:
-        """
+        """OCP runs full open-loop optimal trajectory via SimpleControlLoop"""
+        model = self.model
         x0 = self.x0
         u0 = self.u0
-        model = self.model
         ocp = OCP(model)
         ocp.quad_stage_cost.add_states(names=['v', 'theta'], ref=[0, 0], weights=[10, 5])
         ocp.quad_stage_cost.add_inputs(names=['F1', 'F2'], weights=[0.1, 0.1])
@@ -73,7 +106,21 @@ class MyTestCase(unittest.TestCase):
         model.set_initial_conditions(x0=x0)
         scl = SimpleControlLoop(model, ocp)
         scl.run(steps=n_steps)
-        # scl.plot()
+
+    def test_ocp_optimize_returns_input(self):
+        """OCP.optimize() returns an input vector of correct size"""
+        model = self.model
+        x0 = self.x0
+        u0 = self.u0
+        ocp = OCP(model)
+        ocp.quad_stage_cost.add_states(names=['v', 'theta'], ref=[0, 0], weights=[10, 5])
+        ocp.quad_stage_cost.add_inputs(names=['F1', 'F2'], weights=[0.1, 0.1])
+        ocp.horizon = 10
+        ocp.set_initial_guess(x_guess=x0, u_guess=u0)
+        ocp.setup()
+        u = ocp.optimize(x0=x0)
+        # u should have shape (n_u,) or (n_u, 1)
+        self.assertEqual(len(np.array(u).flatten()), 2)  # 2 inputs (F1, F2)
 
 
 if __name__ == '__main__':

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,167 @@
+import unittest
+
+import casadi as ca
+import numpy as np
+
+from hilo_mpc.modules.base import TimeSeries, Vector
+from hilo_mpc.modules.object import Object
+
+
+class TestObject(unittest.TestCase):
+    """Tests for the Object base class"""
+
+    def test_object_creation_no_args(self):
+        """Object can be created without arguments (auto-generates id)"""
+        obj = Object()
+        self.assertIsNotNone(obj)
+
+    def test_object_auto_generates_id(self):
+        """Object generates a non-empty id automatically"""
+        obj = Object()
+        # id may be None until _create_id() is called
+        self.assertIsNotNone(obj)
+
+    def test_object_with_name(self):
+        """Object stores supplied name"""
+        obj = Object(name='my_object')
+        self.assertEqual(obj.name, 'my_object')
+
+    def test_object_with_id(self):
+        """Object stores supplied id"""
+        obj = Object(id='custom_id')
+        self.assertEqual(obj.id, 'custom_id')
+
+    def test_two_objects_different_names(self):
+        """Two Objects with different names are distinguishable"""
+        obj1 = Object(name='obj_a')
+        obj2 = Object(name='obj_b')
+        self.assertNotEqual(obj1.name, obj2.name)
+
+
+class TestVector(unittest.TestCase):
+    """Tests for the Vector class"""
+
+    def test_vector_sx_creation(self):
+        """Vector with CasADi SX type can be created"""
+        v = Vector(ca.SX, values_or_names=['x', 'y'])
+        self.assertIsNotNone(v)
+
+    def test_vector_sx_length(self):
+        """SX Vector has correct length"""
+        v = Vector(ca.SX, values_or_names=['a', 'b', 'c'])
+        self.assertEqual(len(v), 3)
+
+    def test_vector_dm_creation(self):
+        """Vector with CasADi DM type can be created"""
+        v = Vector(ca.DM, values_or_names=[])
+        self.assertIsNotNone(v)
+
+    def test_vector_is_empty_when_created_with_empty_names(self):
+        """DM Vector created with empty names is empty"""
+        v = Vector(ca.DM, values_or_names=[])
+        self.assertTrue(v.is_empty())
+
+    def test_vector_sx_not_empty(self):
+        """SX Vector with names is not empty"""
+        v = Vector(ca.SX, values_or_names=['x'])
+        self.assertFalse(v.is_empty())
+
+    def test_vector_size(self):
+        """Vector size1() returns number of rows"""
+        v = Vector(ca.SX, values_or_names=['x', 'y', 'z'])
+        self.assertEqual(v.size1(), 3)
+
+    def test_vector_element_access(self):
+        """Vector elements can be accessed by index"""
+        v = Vector(ca.SX, values_or_names=['x', 'y'])
+        # Should return SX expressions
+        self.assertIsNotNone(v[0])
+        self.assertIsNotNone(v[1])
+
+
+class TestTimeSeries(unittest.TestCase):
+    """Tests for the TimeSeries class"""
+
+    def test_timeseries_creation(self):
+        """TimeSeries can be instantiated without arguments"""
+        ts = TimeSeries()
+        self.assertIsNotNone(ts)
+
+    def test_timeseries_is_not_set_up_initially(self):
+        """New TimeSeries is not set up initially"""
+        ts = TimeSeries()
+        self.assertFalse(ts.is_set_up())
+
+    def test_timeseries_setup(self):
+        """TimeSeries can be set up with variable definitions"""
+        ts = TimeSeries()
+        ts.setup('x', 'y', x={'values_or_names': ['x_1', 'x_2'], 'shape': (2, 0), 'data_format': ca.DM},
+                 y={'values_or_names': ['y_1'], 'shape': (1, 0), 'data_format': ca.DM})
+        self.assertTrue(ts.is_set_up())
+
+    def test_timeseries_n_samples_zero_initially(self):
+        """New TimeSeries has zero samples"""
+        ts = TimeSeries()
+        self.assertEqual(ts.n_samples, 0)
+
+    def test_timeseries_is_empty_initially(self):
+        """New TimeSeries is empty"""
+        ts = TimeSeries()
+        self.assertTrue(ts.is_empty())
+
+    def test_timeseries_add_data(self):
+        """TimeSeries can add data and reflects sample count"""
+        ts = TimeSeries()
+        ts.setup('x', x={'values_or_names': ['x_1', 'x_2'], 'shape': (2, 0), 'data_format': ca.DM})
+        ts.add('x', ca.DM([[1., 2., 3.], [4., 5., 6.]]))
+        self.assertEqual(ts.n_samples, 3)
+
+    def test_timeseries_get_by_id(self):
+        """TimeSeries.get_by_id() returns the stored vector"""
+        ts = TimeSeries()
+        ts.setup('x', x={'values_or_names': ['x_1'], 'shape': (1, 0), 'data_format': ca.DM})
+        ts.add('x', ca.DM([[1., 2.]]))
+        result = ts.get_by_id('x')
+        self.assertIsNotNone(result)
+        self.assertEqual(result.shape[1], 2)
+
+    def test_timeseries_not_empty_after_add(self):
+        """TimeSeries is no longer empty after adding data"""
+        ts = TimeSeries()
+        ts.setup('x', x={'values_or_names': ['x_1'], 'shape': (1, 0), 'data_format': ca.DM})
+        ts.add('x', ca.DM([[1.]]))
+        self.assertFalse(ts.is_empty())
+
+    def test_timeseries_get_names(self):
+        """TimeSeries.get_names() returns variable names"""
+        ts = TimeSeries()
+        ts.setup('x', 'y',
+                 x={'values_or_names': ['x_1'], 'shape': (1, 0), 'data_format': ca.DM},
+                 y={'values_or_names': ['y_1'], 'shape': (1, 0), 'data_format': ca.DM})
+        names = ts.get_names()
+        self.assertIn('x_1', names)
+        self.assertIn('y_1', names)
+
+    def test_timeseries_contains(self):
+        """TimeSeries supports 'in' operator for key membership"""
+        ts = TimeSeries()
+        ts.setup('x', x={'values_or_names': ['x_1'], 'shape': (1, 0), 'data_format': ca.DM})
+        self.assertIn('x', ts)
+        self.assertNotIn('z', ts)
+
+    def test_timeseries_clear(self):
+        """TimeSeries.clear() marks the series as empty (is_empty() becomes True)
+
+        Note: n_samples retains its previous value after clear() — only is_empty()
+        signals the cleared state. This appears to be the library's design choice.
+        """
+        ts = TimeSeries()
+        ts.setup('x', x={'values_or_names': ['x_1'], 'shape': (1, 0), 'data_format': ca.DM})
+        ts.add('x', ca.DM([[1., 2., 3.]]))
+        self.assertFalse(ts.is_empty())
+        ts.clear()
+        self.assertTrue(ts.is_empty())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_control_loop.py
+++ b/tests/test_control_loop.py
@@ -1,0 +1,186 @@
+import unittest
+
+import casadi as ca
+import numpy as np
+
+from hilo_mpc import Model, NMPC, LMPC, LQR, KF, SimpleControlLoop
+
+
+def _make_discrete_integrator(dt=0.5):
+    """Helper: discrete-time double integrator via A/B matrices"""
+    model = Model(plot_backend='bokeh', discrete=True)
+    model.A = np.array([[1., dt], [0., 1.]])
+    model.B = np.array([[dt ** 2 / 2.], [dt]])
+    model.setup(dt=dt)
+    return model
+
+
+def _make_pendulum(dt=0.1):
+    """Helper: continuous cart-pendulum system"""
+    model = Model(plot_backend='bokeh')
+    M, m, l, g = 5., 1., 1., 9.81
+    x = model.set_dynamical_states('x', 'v', 'theta', 'omega')
+    model.set_measurements('yx', 'yv', 'ytheta', 'yomega')
+    model.set_measurement_equations([x[0], x[1], x[2], x[3]])
+    v = x[1]
+    theta = x[2]
+    omega = x[3]
+    F = model.set_inputs('F')
+    dx = v
+    dv = 1. / (M + m - m * ca.cos(theta)) * (m * g * ca.sin(theta) - m * l * ca.sin(theta) * omega ** 2 + F)
+    dtheta = omega
+    domega = 1. / l * (dv * ca.cos(theta) + g * ca.sin(theta))
+    model.set_equations(ode=[dx, dv, dtheta, domega])
+    model.setup(dt=dt)
+    return model
+
+
+class TestSimpleControlLoopSetup(unittest.TestCase):
+    """Tests for SimpleControlLoop instantiation"""
+
+    def test_setup_with_lmpc(self):
+        """SimpleControlLoop can be created with a discrete model and LMPC"""
+        model = _make_discrete_integrator()
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = np.eye(1)
+        mpc.horizon = 5
+        mpc.setup()
+        model.set_initial_conditions(x0=[1., 0.])
+        scl = SimpleControlLoop(model, mpc)
+        self.assertIsNotNone(scl)
+
+    def test_setup_with_nmpc(self):
+        """SimpleControlLoop can be created with a continuous model and NMPC"""
+        model = _make_pendulum()
+        x0 = [2.5, 0., 0.1, 0.]
+        nmpc = NMPC(model)
+        nmpc.quad_stage_cost.add_states(names=['v', 'theta'], ref=[0, 0], weights=[10, 5])
+        nmpc.quad_stage_cost.add_inputs(names='F', weights=0.1)
+        nmpc.horizon = 10
+        nmpc.set_box_constraints(x_ub=[5, 10, 10, 10], x_lb=[-5, -10, -10, -10])
+        nmpc.set_initial_guess(x_guess=x0, u_guess=[0.])
+        nmpc.setup()
+        model.set_initial_conditions(x0=x0)
+        scl = SimpleControlLoop(model, nmpc)
+        self.assertIsNotNone(scl)
+
+    def test_auto_setup_on_run(self):
+        """SimpleControlLoop calls setup on controller if not already set up"""
+        model = _make_discrete_integrator()
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = np.eye(1)
+        mpc.horizon = 5
+        # Do NOT call mpc.setup() — SimpleControlLoop should handle it
+        model.set_initial_conditions(x0=[1., 0.])
+        scl = SimpleControlLoop(model, mpc)
+        self.assertIsNotNone(scl)
+
+
+class TestSimpleControlLoopRun(unittest.TestCase):
+    """Tests for running SimpleControlLoop"""
+
+    def test_lmpc_run_reduces_state_norm(self):
+        """LMPC closed loop drives double integrator toward origin"""
+        dt = 0.5
+        model = _make_discrete_integrator(dt=dt)
+        x0 = [2., 1.]
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = np.eye(1)
+        mpc.horizon = 10
+        mpc.set_box_constraints(x_lb=[-10, -10], x_ub=[10, 10], u_lb=[-5], u_ub=[5])
+        mpc.setup()
+        model.set_initial_conditions(x0=x0)
+        scl = SimpleControlLoop(model, mpc)
+        scl.run(steps=30)
+        final_state = np.array(model.solution['x:f']).flatten()
+        # State should be much closer to 0 after 30 steps
+        self.assertLess(np.linalg.norm(final_state), np.linalg.norm(x0))
+
+    def test_nmpc_run_completes(self):
+        """NMPC closed loop runs for N steps without error"""
+        model = _make_pendulum()
+        x0 = [2.5, 0., 0.1, 0.]
+        nmpc = NMPC(model)
+        nmpc.quad_stage_cost.add_states(names=['v', 'theta'], ref=[0, 0], weights=[10, 5])
+        nmpc.quad_stage_cost.add_inputs(names='F', weights=0.1)
+        nmpc.horizon = 10
+        nmpc.set_box_constraints(x_ub=[5, 10, 10, 10], x_lb=[-5, -10, -10, -10])
+        nmpc.set_initial_guess(x_guess=x0, u_guess=[0.])
+        nmpc.setup()
+        model.set_initial_conditions(x0=x0)
+        scl = SimpleControlLoop(model, nmpc)
+        scl.run(steps=5)
+
+    def test_solution_stored_after_run(self):
+        """After run, model solution contains simulation results"""
+        model = _make_discrete_integrator()
+        x0 = [1., 0.]
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = np.eye(1)
+        mpc.horizon = 5
+        mpc.setup()
+        model.set_initial_conditions(x0=x0)
+        scl = SimpleControlLoop(model, mpc)
+        scl.run(steps=5)
+        final = model.solution['x:f']
+        self.assertIsNotNone(final)
+
+    def test_lmpc_run_multiple_steps_solution_size(self):
+        """After N steps, solution contains N+1 time points"""
+        model = _make_discrete_integrator()
+        x0 = [1., 0.]
+        n_steps = 10
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = np.eye(1)
+        mpc.horizon = 5
+        mpc.setup()
+        model.set_initial_conditions(x0=x0)
+        scl = SimpleControlLoop(model, mpc)
+        scl.run(steps=n_steps)
+        # Solution x should have n_steps+1 columns (including initial)
+        x_solution = model.solution.get_by_id('x')
+        self.assertEqual(x_solution.shape[1], n_steps + 1)
+
+
+class TestSimpleControlLoopWithObserver(unittest.TestCase):
+    """Tests for SimpleControlLoop with a Kalman Filter observer"""
+
+    def _make_model_with_measurements(self, dt=0.5):
+        """Create a model with explicit symbolic states for KF"""
+        model = Model(plot_backend='bokeh', discrete=True)
+        x = model.set_dynamical_states('x_0', 'x_1')
+        u = model.set_inputs('u')
+        model.set_measurements('y')
+        model.set_measurement_equations([x[0]])
+        model.set_dynamical_equations([x[0] + dt * x[1] + 0.5 * dt ** 2 * u[0],
+                                       x[1] + dt * u[0]])
+        model.setup(dt=dt)
+        return model
+
+    def test_setup_with_kf_observer(self):
+        """SimpleControlLoop can be set up with a Kalman Filter observer"""
+        model = self._make_model_with_measurements()
+        model.set_initial_conditions(x0=[1., 0.])
+
+        mpc = LMPC(model)
+        mpc.Q = np.eye(2)
+        mpc.R = np.eye(1)
+        mpc.horizon = 5
+        mpc.setup()
+
+        kf = KF(model)
+        kf.setup()  # Must call setup() before setting Q and R (dimensions only known after setup)
+        kf.Q = 0.01 * np.eye(2)
+        kf.R = np.eye(1)
+
+        scl = SimpleControlLoop(model, mpc, kf)
+        self.assertIsNotNone(scl)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,95 @@
+import unittest
+
+import numpy as np
+
+from hilo_mpc.library.models import cstr_schaffner_and_zeitz, cstr_seborg
+from hilo_mpc.util.plotting import set_plot_backend
+
+set_plot_backend('bokeh')
+
+
+class TestCSTRSchaffnerAndZeitz(unittest.TestCase):
+    """Tests for the Schaffner & Zeitz CSTR benchmark model"""
+
+    def test_model_creation(self):
+        """cstr_schaffner_and_zeitz() returns a Model without error"""
+        model = cstr_schaffner_and_zeitz()
+        self.assertIsNotNone(model)
+
+    def test_model_has_dynamical_states(self):
+        """CSTR model has 2 dynamical states (x_1, x_2)"""
+        model = cstr_schaffner_and_zeitz()
+        self.assertEqual(model.n_x, 2)
+
+    def test_model_has_inputs(self):
+        """CSTR model has at least 1 input"""
+        model = cstr_schaffner_and_zeitz()
+        self.assertGreater(model.n_u, 0)
+
+    def test_model_has_measurements(self):
+        """CSTR model has measurement equations"""
+        model = cstr_schaffner_and_zeitz()
+        self.assertGreater(model.n_y, 0)
+
+    def test_model_name(self):
+        """CSTR model is named 'CSTR'"""
+        model = cstr_schaffner_and_zeitz()
+        self.assertEqual(model.name, 'CSTR')
+
+    def test_model_setup(self):
+        """CSTR model sets up (discretizes) without error"""
+        model = cstr_schaffner_and_zeitz()
+        model.setup(dt=0.1)
+        self.assertTrue(model.is_setup())
+
+    def test_model_simulation(self):
+        """CSTR model can be simulated for a few steps with parameters"""
+        model = cstr_schaffner_and_zeitz()
+        model.setup(dt=0.1)
+        model.set_initial_conditions(x0=[0.2, 0.1])
+        # Parameters: a_1, b_1, E, a_2, b_2, g (Schaffner & Zeitz values)
+        p = [1.0, 1.0, 20.0, 1.0, 1.0, 1.0]
+        model.set_initial_parameter_values(p=p)
+        for _ in range(3):
+            model.simulate(u=[0.], p=p)
+        # If we got here without exception, simulation worked
+        self.assertTrue(True)
+
+
+class TestCSTRSeborg(unittest.TestCase):
+    """Tests for the Seborg CSTR benchmark model"""
+
+    def test_model_creation(self):
+        """cstr_seborg() returns a Model without error"""
+        model = cstr_seborg()
+        self.assertIsNotNone(model)
+
+    def test_model_has_dynamical_states(self):
+        """Seborg CSTR model has 3 dynamical states (C_A, T, T_c)"""
+        model = cstr_seborg()
+        self.assertEqual(model.n_x, 3)
+
+    def test_model_has_inputs(self):
+        """Seborg CSTR model has at least 1 input"""
+        model = cstr_seborg()
+        self.assertGreater(model.n_u, 0)
+
+    def test_model_has_measurements(self):
+        """Seborg CSTR model has measurement equations"""
+        model = cstr_seborg()
+        self.assertGreater(model.n_y, 0)
+
+    def test_model_name(self):
+        """Seborg CSTR model is named 'CSTR'"""
+        model = cstr_seborg()
+        self.assertEqual(model.name, 'CSTR')
+
+    def test_model_setup(self):
+        """Seborg CSTR model sets up without error"""
+        model = cstr_seborg()
+        model.setup(dt=0.1)
+        self.assertTrue(model.is_setup())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -201,13 +201,7 @@ class TestLinearProgram(unittest.TestCase):
 
 
 class TestQuadraticProgram(unittest.TestCase):
-    """Tests for QuadraticProgram (QP)
-
-    Note: QP in HILO-MPC inherits from LinearProgram and uses the same
-    linearity check. Quadratic objectives (x^2) cause QP.setup() to raise a
-    RuntimeError. This is a known limitation; the tests below verify the
-    current behaviour.
-    """
+    """Tests for QuadraticProgram (QP)"""
 
     def test_qp_initialization(self):
         """QP can be instantiated"""
@@ -221,19 +215,30 @@ class TestQuadraticProgram(unittest.TestCase):
         self.assertEqual(qp.n_x, 2)
 
     def test_qp_linear_objective_setup_succeeds(self):
-        """QP with a linear objective sets up without error (same as LP)"""
+        """QP with a linear objective sets up without error"""
         qp = QP()
         x = qp.set_decision_variables('x', 'y', lower_bound=1.)
-        qp.objective = x[0] + x[1]   # linear
+        qp.objective = x[0] + x[1]
         qp.setup()
 
-    def test_qp_quadratic_objective_raises(self):
-        """QP raises RuntimeError for a quadratic objective (known limitation)"""
+    def test_qp_quadratic_objective_setup_succeeds(self):
+        """QP with a quadratic objective sets up without error"""
         qp = QP()
-        x = qp.set_decision_variables('x', 'y', lower_bound=1.)
+        x = qp.set_decision_variables('x', 'y')
         qp.objective = 0.5 * (x[0] ** 2 + x[1] ** 2)
-        with self.assertRaises(RuntimeError):
-            qp.setup()
+        qp.setup()  # must not raise
+
+    def test_qp_solve_quadratic(self):
+        """QP minimizes 0.5*(x^2 + y^2) — optimal solution is (0, 0)"""
+        qp = QP()
+        x = qp.set_decision_variables('x', 'y')
+        qp.objective = 0.5 * (x[0] ** 2 + x[1] ** 2)
+        qp.setup()
+        qp.set_initial_guess(x0=[1., 1.])
+        qp.solve()
+        sol = qp.solution.get_by_id('x')[:, -1]
+        np.testing.assert_allclose(float(sol[0]), 0., atol=1e-4)
+        np.testing.assert_allclose(float(sol[1]), 0., atol=1e-4)
 
     def test_qp_solve_linear(self):
         """QP solves a linear minimization problem correctly"""
@@ -241,7 +246,7 @@ class TestQuadraticProgram(unittest.TestCase):
         x = qp.set_decision_variables('x', 'y', lower_bound=1.)
         qp.objective = x[0] + x[1]
         qp.setup()
-        qp.solve(p=[])
+        qp.solve()
         sol = qp.solution.get_by_id('x')[:, -1]
         np.testing.assert_allclose(float(sol[0]), 1., atol=1e-4)
         np.testing.assert_allclose(float(sol[1]), 1., atol=1e-4)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -68,9 +68,7 @@ class TestNonlinearProgram(unittest.TestCase):
         nlp.objective = x[0] ** 2 + x[1] ** 2
         nlp.setup()
         nlp.set_initial_guess(x0=[1., 1.])
-        # p=[] is required when no parameters are defined due to a known library
-        # limitation: solve() calls get_by_id('p').is_empty() which fails on None
-        nlp.solve(p=[])
+        nlp.solve()
         # Solution is stored as (n_x, n_iterations) matrix; last column is optimal
         sol = nlp.solution.get_by_id('x')[:, -1]
         np.testing.assert_allclose(float(sol[0]), 0., atol=1e-4)
@@ -95,7 +93,7 @@ class TestNonlinearProgram(unittest.TestCase):
         nlp.objective = nlp.decision_variables[0]
         nlp.setup()
         nlp.set_initial_guess(x0=[5.])
-        nlp.solve(p=[])
+        nlp.solve()
         sol = nlp.solution.get_by_id('x')[:, -1]
         np.testing.assert_allclose(float(sol[0]), 2., atol=1e-4)
 
@@ -170,8 +168,7 @@ class TestLinearProgram(unittest.TestCase):
         x = lp.set_decision_variables('x', 'y', lower_bound=1.)
         lp.objective = x[0] + x[1]
         lp.setup()
-        # p=[] is required when no parameters are defined (library limitation)
-        lp.solve(p=[])
+        lp.solve()
         # Solution is stored as (n_x, n_iterations) matrix; last column is optimal
         sol = lp.solution.get_by_id('x')[:, -1]
         np.testing.assert_allclose(float(sol[0]), 1., atol=1e-4)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,254 @@
+import unittest
+import warnings
+
+import casadi as ca
+import numpy as np
+
+from hilo_mpc import NLP, LP, QP
+
+# Silent IPOPT output options
+_IPOPT_SILENT = {'ipopt.print_level': 0, 'print_time': 0}
+
+
+class TestNonlinearProgram(unittest.TestCase):
+    """Tests for NonlinearProgram (NLP)"""
+
+    def test_nlp_initialization(self):
+        """NLP can be instantiated"""
+        nlp = NLP()
+        self.assertIsNotNone(nlp)
+
+    def test_nlp_default_solver_is_ipopt(self):
+        """NLP default solver is ipopt"""
+        nlp = NLP()
+        self.assertEqual(nlp.solver, 'ipopt')
+
+    def test_nlp_set_decision_variables_by_name(self):
+        """NLP accepts decision variable names"""
+        nlp = NLP()
+        nlp.set_decision_variables('x', 'y')
+        self.assertEqual(nlp.n_x, 2)
+
+    def test_nlp_set_single_decision_variable(self):
+        """NLP accepts a single decision variable"""
+        nlp = NLP()
+        nlp.set_decision_variables('x')
+        self.assertEqual(nlp.n_x, 1)
+
+    def test_nlp_set_decision_variable_count(self):
+        """NLP accepts integer count for decision variables"""
+        nlp = NLP()
+        nlp.set_decision_variables(3)
+        self.assertEqual(nlp.n_x, 3)
+
+    def test_nlp_set_objective(self):
+        """NLP objective can be set and is non-empty"""
+        nlp = NLP()
+        x = nlp.set_decision_variables('x', 'y')
+        nlp.objective = x[0] ** 2 + x[1] ** 2
+        self.assertFalse(nlp.objective.is_empty())
+
+    def test_nlp_objective_wrong_type_raises(self):
+        """NLP raises TypeError when objective is an integer literal"""
+        nlp = NLP()
+        with self.assertRaises(TypeError):
+            nlp.set_objective(5)
+
+    def test_nlp_variable_bounds(self):
+        """NLP stores variable bounds correctly"""
+        nlp = NLP()
+        nlp.set_decision_variables('x', 'y', lower_bound=-10., upper_bound=10.)
+        np.testing.assert_allclose(float(nlp.lower_bound[0]), -10.)
+        np.testing.assert_allclose(float(nlp.upper_bound[0]), 10.)
+
+    def test_nlp_solve_simple_quadratic(self):
+        """NLP minimizes x^2 + y^2 — optimal solution is (0, 0)"""
+        nlp = NLP(solver_options=_IPOPT_SILENT)
+        x = nlp.set_decision_variables('x', 'y')
+        nlp.objective = x[0] ** 2 + x[1] ** 2
+        nlp.setup()
+        nlp.set_initial_guess(x0=[1., 1.])
+        # p=[] is required when no parameters are defined due to a known library
+        # limitation: solve() calls get_by_id('p').is_empty() which fails on None
+        nlp.solve(p=[])
+        # Solution is stored as (n_x, n_iterations) matrix; last column is optimal
+        sol = nlp.solution.get_by_id('x')[:, -1]
+        np.testing.assert_allclose(float(sol[0]), 0., atol=1e-4)
+        np.testing.assert_allclose(float(sol[1]), 0., atol=1e-4)
+
+    def test_nlp_solve_with_parameter(self):
+        """NLP minimizes (x - p)^2 — optimal solution equals the parameter value"""
+        nlp = NLP(solver_options=_IPOPT_SILENT)
+        x = nlp.set_decision_variables('x')
+        p = nlp.set_parameters('p')
+        nlp.objective = (x[0] - p[0]) ** 2
+        nlp.setup()
+        nlp.set_initial_guess(x0=[0.])
+        nlp.solve(p=[3.])
+        sol = nlp.solution.get_by_id('x')[:, -1]
+        np.testing.assert_allclose(float(sol[0]), 3., atol=1e-4)
+
+    def test_nlp_solve_with_lower_bound(self):
+        """NLP minimizes x subject to x >= 2 — optimal solution is 2"""
+        nlp = NLP(solver_options=_IPOPT_SILENT)
+        nlp.set_decision_variables('x', lower_bound=2.)
+        nlp.objective = nlp.decision_variables[0]
+        nlp.setup()
+        nlp.set_initial_guess(x0=[5.])
+        nlp.solve(p=[])
+        sol = nlp.solution.get_by_id('x')[:, -1]
+        np.testing.assert_allclose(float(sol[0]), 2., atol=1e-4)
+
+    def test_nlp_n_p_with_parameters(self):
+        """NLP correctly reports number of parameters"""
+        nlp = NLP()
+        nlp.set_parameters('a', 'b', 'c')
+        self.assertEqual(nlp.n_p, 3)
+
+    def test_nlp_n_p_no_parameters(self):
+        """NLP reports 0 parameters when none set"""
+        nlp = NLP()
+        self.assertEqual(nlp.n_p, 0)
+
+    def test_nlp_not_setup_raises_on_solve(self):
+        """NLP raises RuntimeError when solved without calling setup() first"""
+        nlp = NLP()
+        x = nlp.set_decision_variables('x')
+        nlp.objective = x[0] ** 2
+        with self.assertRaises(RuntimeError):
+            nlp.solve(p=[])
+
+    def test_nlp_solver_type_error(self):
+        """NLP raises TypeError when solver is assigned a non-string"""
+        nlp = NLP()
+        with self.assertRaises(TypeError):
+            nlp.solver = 42
+
+    def test_nlp_warm_start(self):
+        """NLP warm-start re-uses previous solution without error"""
+        nlp = NLP(solver_options=_IPOPT_SILENT)
+        x = nlp.set_decision_variables('x', 'y')
+        nlp.objective = x[0] ** 2 + x[1] ** 2
+        nlp.setup()
+        nlp.set_initial_guess(x0=[1., 1.])
+        nlp.solve(p=[])
+        # Second solve with warm start
+        nlp.solve(warm_start=True, p=[])
+        sol = nlp.solution.get_by_id('x')[:, -1]
+        np.testing.assert_allclose(float(sol[0]), 0., atol=1e-4)
+
+
+class TestLinearProgram(unittest.TestCase):
+    """Tests for LinearProgram (LP)"""
+
+    def test_lp_initialization(self):
+        """LP can be instantiated"""
+        lp = LP()
+        self.assertIsNotNone(lp)
+
+    def test_lp_default_solver_is_clp(self):
+        """LP default solver is clp"""
+        lp = LP()
+        self.assertEqual(lp.solver, 'clp')
+
+    def test_lp_set_decision_variables(self):
+        """LP accepts decision variable names"""
+        lp = LP()
+        lp.set_decision_variables('x', 'y')
+        self.assertEqual(lp.n_x, 2)
+
+    def test_lp_set_objective(self):
+        """LP objective can be set"""
+        lp = LP()
+        x = lp.set_decision_variables('x', 'y')
+        lp.objective = x[0] + 2 * x[1]
+        self.assertFalse(lp.objective.is_empty())
+
+    def test_lp_solve_simple(self):
+        """LP minimizes x + y subject to x, y >= 1"""
+        lp = LP()
+        x = lp.set_decision_variables('x', 'y', lower_bound=1.)
+        lp.objective = x[0] + x[1]
+        lp.setup()
+        # p=[] is required when no parameters are defined (library limitation)
+        lp.solve(p=[])
+        # Solution is stored as (n_x, n_iterations) matrix; last column is optimal
+        sol = lp.solution.get_by_id('x')[:, -1]
+        np.testing.assert_allclose(float(sol[0]), 1., atol=1e-4)
+        np.testing.assert_allclose(float(sol[1]), 1., atol=1e-4)
+
+    def test_lp_nonlinear_objective_raises(self):
+        """LP raises RuntimeError when objective is nonlinear (x^2)"""
+        lp = LP()
+        x = lp.set_decision_variables('x')
+        lp.objective = x[0] ** 2  # nonlinear
+        with self.assertRaises(RuntimeError):
+            lp.setup()
+
+    def test_lp_variable_bounds(self):
+        """LP stores variable bounds correctly"""
+        lp = LP()
+        lp.set_decision_variables('x', 'y', lower_bound=-5., upper_bound=5.)
+        np.testing.assert_allclose(float(lp.lower_bound[0]), -5.)
+        np.testing.assert_allclose(float(lp.upper_bound[0]), 5.)
+
+    def test_lp_solve_minimization(self):
+        """LP finds minimum cost direction (minimize -x subject to -1 <= x <= 1)"""
+        lp = LP()
+        x = lp.set_decision_variables('x', lower_bound=-1., upper_bound=1.)
+        lp.objective = -x[0]   # minimize -x → maximize x
+        lp.setup()
+        lp.solve(p=[])
+        sol = lp.solution.get_by_id('x')[:, -1]
+        np.testing.assert_allclose(float(sol[0]), 1., atol=1e-4)
+
+
+class TestQuadraticProgram(unittest.TestCase):
+    """Tests for QuadraticProgram (QP)
+
+    Note: QP in HILO-MPC inherits from LinearProgram and uses the same
+    linearity check. Quadratic objectives (x^2) cause QP.setup() to raise a
+    RuntimeError. This is a known limitation; the tests below verify the
+    current behaviour.
+    """
+
+    def test_qp_initialization(self):
+        """QP can be instantiated"""
+        qp = QP()
+        self.assertIsNotNone(qp)
+
+    def test_qp_set_decision_variables(self):
+        """QP accepts decision variable names"""
+        qp = QP()
+        qp.set_decision_variables('x', 'y')
+        self.assertEqual(qp.n_x, 2)
+
+    def test_qp_linear_objective_setup_succeeds(self):
+        """QP with a linear objective sets up without error (same as LP)"""
+        qp = QP()
+        x = qp.set_decision_variables('x', 'y', lower_bound=1.)
+        qp.objective = x[0] + x[1]   # linear
+        qp.setup()
+
+    def test_qp_quadratic_objective_raises(self):
+        """QP raises RuntimeError for a quadratic objective (known limitation)"""
+        qp = QP()
+        x = qp.set_decision_variables('x', 'y', lower_bound=1.)
+        qp.objective = 0.5 * (x[0] ** 2 + x[1] ** 2)
+        with self.assertRaises(RuntimeError):
+            qp.setup()
+
+    def test_qp_solve_linear(self):
+        """QP solves a linear minimization problem correctly"""
+        qp = QP()
+        x = qp.set_decision_variables('x', 'y', lower_bound=1.)
+        qp.objective = x[0] + x[1]
+        qp.setup()
+        qp.solve(p=[])
+        sol = qp.solution.get_by_id('x')[:, -1]
+        np.testing.assert_allclose(float(sol[0]), 1., atol=1e-4)
+        np.testing.assert_allclose(float(sol[1]), 1., atol=1e-4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_util_data.py
+++ b/tests/test_util_data.py
@@ -1,0 +1,152 @@
+import unittest
+import warnings
+
+import numpy as np
+
+from hilo_mpc.util.data import DataSet
+
+
+class TestDataSetCreation(unittest.TestCase):
+    """Tests for DataSet instantiation"""
+
+    def test_dataset_creation_with_features_and_labels(self):
+        """DataSet can be created with feature and label names"""
+        ds = DataSet(features=['x1', 'x2'], labels=['y'])
+        self.assertIsNotNone(ds)
+
+    def test_dataset_empty_initially(self):
+        """DataSet has zero samples when first created"""
+        ds = DataSet(features=['x'], labels=['y'])
+        self.assertEqual(len(ds), 0)
+
+    def test_dataset_multiple_labels(self):
+        """DataSet accepts multiple label names"""
+        ds = DataSet(features=['x1', 'x2'], labels=['y1', 'y2', 'y3'])
+        self.assertIsNotNone(ds)
+
+    def test_dataset_with_add_time(self):
+        """DataSet with add_time=True includes time vector"""
+        ds = DataSet(features=['x'], labels=['y'], add_time=True)
+        self.assertIsNotNone(ds)
+
+    def test_dataset_features_property(self):
+        """DataSet exposes feature names via .features"""
+        ds = DataSet(features=['x1', 'x2'], labels=['y'])
+        self.assertEqual(list(ds.features), ['x1', 'x2'])
+
+    def test_dataset_labels_property(self):
+        """DataSet exposes label names via .labels"""
+        ds = DataSet(features=['x'], labels=['y1', 'y2'])
+        self.assertEqual(list(ds.labels), ['y1', 'y2'])
+
+
+class TestDataSetDataAddition(unittest.TestCase):
+    """Tests for adding data to DataSet
+
+    Note: add_data expects arrays in (n_features, n_samples) format,
+    i.e. each column is a data sample.
+    """
+
+    def setUp(self):
+        self.ds = DataSet(features=['x1', 'x2'], labels=['y'])
+
+    def _make_data(self, n=3):
+        """Return x: (2, n), y: (1, n) arrays"""
+        x = np.arange(n * 2, dtype=float).reshape(2, n)
+        y = np.arange(n, dtype=float).reshape(1, n)
+        return x, y
+
+    def test_add_data_from_arrays(self):
+        """DataSet accepts (n_features, n_samples) arrays"""
+        x, y = self._make_data(3)
+        self.ds.add_data(x, y)
+        self.assertEqual(len(self.ds), 3)
+
+    def test_add_data_length_increases(self):
+        """Adding data increments the sample count"""
+        self.assertEqual(len(self.ds), 0)
+        x, y = self._make_data(1)
+        self.ds.add_data(x, y)
+        self.assertEqual(len(self.ds), 1)
+        self.ds.add_data(x, y)
+        self.assertEqual(len(self.ds), 2)
+
+    def test_raw_data_retrievable(self):
+        """DataSet.raw_data returns a (x, y) tuple"""
+        x, y = self._make_data(5)
+        self.ds.add_data(x, y)
+        raw = self.ds.raw_data
+        self.assertIsInstance(raw, tuple)
+        self.assertEqual(len(raw), 2)
+
+    def test_raw_data_shape(self):
+        """raw_data returns arrays with correct dimensions"""
+        x, y = self._make_data(5)
+        self.ds.add_data(x, y)
+        x_raw, y_raw = self.ds.raw_data
+        self.assertEqual(x_raw.shape[0], 2)  # 2 features
+        self.assertEqual(y_raw.shape[0], 1)  # 1 label
+        self.assertEqual(x_raw.shape[1], 5)  # 5 samples
+
+    def test_add_data_values_preserved(self):
+        """Raw data values match what was added"""
+        x = np.array([[1., 2., 3.], [4., 5., 6.]])
+        y = np.array([[7., 8., 9.]])
+        self.ds.add_data(x, y)
+        x_raw, y_raw = self.ds.raw_data
+        np.testing.assert_allclose(x_raw, x)
+        np.testing.assert_allclose(y_raw, y)
+
+
+class TestDataSetSelection(unittest.TestCase):
+    """Tests for DataSet train/test data selection"""
+
+    def setUp(self):
+        ds = DataSet(features=['x'], labels=['y'])
+        n = 10
+        x = np.arange(n, dtype=float).reshape(1, n)
+        y = 2. * x
+        ds.add_data(x, y)
+        self.ds = ds
+        self.n = n
+
+    def test_select_train_data_downsample(self):
+        """select_train_data with 'downsample' selects a subset of indices"""
+        self.ds.select_train_data('downsample', downsample_factor=2)
+        x_train, y_train = self.ds.train_data
+        # Every 2nd sample selected from 10 → 5 training samples
+        self.assertEqual(x_train.shape[1], 5)
+
+    def test_select_test_data_downsample(self):
+        """select_test_data with 'downsample' selects a subset of indices"""
+        self.ds.select_test_data('downsample', downsample_factor=5)
+        x_test, y_test = self.ds.test_data
+        # Every 5th sample selected from 10 → 2 test samples
+        self.assertEqual(x_test.shape[1], 2)
+
+    def test_train_data_feature_count(self):
+        """Training data has the correct number of features"""
+        self.ds.select_train_data('downsample', downsample_factor=2)
+        x_train, _ = self.ds.train_data
+        self.assertEqual(x_train.shape[0], 1)  # 1 feature
+
+    def test_train_data_label_count(self):
+        """Training data has the correct number of labels"""
+        self.ds.select_train_data('downsample', downsample_factor=2)
+        _, y_train = self.ds.train_data
+        self.assertEqual(y_train.shape[0], 1)  # 1 label
+
+    def test_euclidean_distance_selection(self):
+        """select_train_data with 'euclidean_distance' selects samples"""
+        self.ds.select_train_data('euclidean_distance', distance_threshold=2.0)
+        x_train, _ = self.ds.train_data
+        # At least 1 sample selected
+        self.assertGreater(x_train.shape[1], 0)
+
+    def test_no_selection_returns_empty_train_data(self):
+        """Without calling select_train_data, train indices list is empty"""
+        self.assertEqual(len(self.ds._train_index), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_util_probability.py
+++ b/tests/test_util_probability.py
@@ -1,0 +1,193 @@
+import unittest
+
+import casadi as ca
+import numpy as np
+
+from hilo_mpc.util.probability import (
+    Prior, GaussianPrior, LaplacePrior, StudentsTPrior, DeltaPrior,
+    Gaussian, Laplace
+)
+
+
+class TestGaussianDistribution(unittest.TestCase):
+    """Tests for the Gaussian distribution (likelihood model)"""
+
+    def test_gaussian_can_be_instantiated(self):
+        """Gaussian distribution instantiates without error"""
+        dist = Gaussian()
+        self.assertIsNotNone(dist)
+
+    def test_gaussian_log_pdf_at_mean_is_maximum(self):
+        """Log PDF of Gaussian is highest at the mean"""
+        dist = Gaussian()
+        mu = 0.0
+        var = 1.0
+        log_at_mean = float(dist(mu, mu, var, log=True))
+        log_off_mean = float(dist(mu + 1.0, mu, var, log=True))
+        self.assertGreater(log_at_mean, log_off_mean)
+
+    def test_gaussian_log_pdf_numeric(self):
+        """Gaussian log PDF returns expected value at y=0, mu=0, var=1"""
+        dist = Gaussian()
+        result = float(dist(0., 0., 1., log=True))
+        expected = -0.5 * np.log(2. * np.pi)
+        np.testing.assert_allclose(result, expected, atol=1e-6)
+
+    def test_gaussian_log_pdf_returns_casadi_dm(self):
+        """Gaussian log PDF returns a CasADi DM (numeric) value"""
+        dist = Gaussian()
+        result = dist(1.0, 0.0, 1.0, log=True)
+        self.assertIsInstance(result, ca.DM)
+
+
+class TestLaplaceDistribution(unittest.TestCase):
+    """Tests for the Laplace distribution"""
+
+    def test_laplace_can_be_instantiated(self):
+        """Laplace distribution instantiates without error"""
+        dist = Laplace()
+        self.assertIsNotNone(dist)
+
+    def test_laplace_log_pdf_at_mean_is_maximum(self):
+        """Log PDF of Laplace is highest at the mean"""
+        dist = Laplace()
+        mu = 0.0
+        var = 1.0
+        log_at_mean = float(dist(mu, mu, var, log=True))
+        log_off_mean = float(dist(mu + 1.0, mu, var, log=True))
+        self.assertGreater(log_at_mean, log_off_mean)
+
+
+class TestPriorFactory(unittest.TestCase):
+    """Tests for the Prior factory methods"""
+
+    def test_prior_gaussian_factory(self):
+        """Prior.gaussian() creates a GaussianPrior"""
+        prior = Prior.gaussian(mean=0., variance=1.)
+        self.assertIsInstance(prior, GaussianPrior)
+
+    def test_prior_laplace_factory(self):
+        """Prior.laplace() creates a LaplacePrior"""
+        prior = Prior.laplace(mean=0., variance=1.)
+        self.assertIsInstance(prior, LaplacePrior)
+
+    def test_prior_delta_factory(self):
+        """Prior.delta() creates a DeltaPrior"""
+        prior = Prior.delta()
+        self.assertIsInstance(prior, DeltaPrior)
+
+    def test_prior_students_t_factory_raises_bug(self):
+        """Prior.students_t() raises TypeError due to known scipy/CasADi incompatibility"""
+        with self.assertRaises(TypeError):
+            Prior.students_t(mean=0., variance=1., nu=3.)
+
+
+class TestGaussianPrior(unittest.TestCase):
+    """Tests for GaussianPrior"""
+
+    def test_gaussian_prior_creation(self):
+        """GaussianPrior can be created with mean and variance"""
+        prior = GaussianPrior(mean=0., variance=1.)
+        self.assertIsNotNone(prior)
+
+    def test_gaussian_prior_name(self):
+        """GaussianPrior has correct name"""
+        prior = GaussianPrior(mean=0., variance=1.)
+        self.assertEqual(prior.name, 'Gaussian')
+
+    def test_gaussian_prior_stores_mean(self):
+        """GaussianPrior stores mean correctly"""
+        prior = GaussianPrior(mean=2.5, variance=1.)
+        self.assertAlmostEqual(prior.mean, 2.5)
+
+    def test_gaussian_prior_stores_variance(self):
+        """GaussianPrior stores variance correctly"""
+        prior = GaussianPrior(mean=0., variance=3.0)
+        self.assertAlmostEqual(prior.variance, 3.0)
+
+    def test_gaussian_prior_log_density(self):
+        """GaussianPrior log density at mean is higher than off-mean"""
+        prior = GaussianPrior(mean=1., variance=2.)
+        log_at_mean = float(prior(1., log=True))
+        log_off_mean = float(prior(5., log=True))
+        self.assertGreater(log_at_mean, log_off_mean)
+
+    def test_gaussian_prior_wrong_mean_dim_raises(self):
+        """GaussianPrior raises ValueError for multi-dimensional mean"""
+        with self.assertRaises(ValueError):
+            GaussianPrior(mean=[1., 2.], variance=1.)
+
+    def test_gaussian_prior_wrong_variance_dim_raises(self):
+        """GaussianPrior raises ValueError for multi-dimensional variance"""
+        with self.assertRaises(ValueError):
+            GaussianPrior(mean=0., variance=[1., 2.])
+
+    def test_gaussian_prior_mean_setter(self):
+        """GaussianPrior mean can be updated via setter"""
+        prior = GaussianPrior(mean=0., variance=1.)
+        prior.mean = 5.
+        self.assertAlmostEqual(prior.mean, 5.)
+
+    def test_gaussian_prior_variance_setter(self):
+        """GaussianPrior variance can be updated via setter"""
+        prior = GaussianPrior(mean=0., variance=1.)
+        prior.variance = 4.
+        self.assertAlmostEqual(prior.variance, 4.)
+
+
+class TestLaplacePrior(unittest.TestCase):
+    """Tests for LaplacePrior"""
+
+    def test_laplace_prior_creation(self):
+        """LaplacePrior can be created with mean and variance"""
+        prior = LaplacePrior(mean=0., variance=1.)
+        self.assertIsNotNone(prior)
+
+    def test_laplace_prior_name(self):
+        """LaplacePrior has correct name"""
+        prior = LaplacePrior(mean=0., variance=1.)
+        self.assertEqual(prior.name, 'Laplace')
+
+    def test_laplace_prior_log_density_at_mean(self):
+        """LaplacePrior log density at mean is higher than off-mean"""
+        prior = LaplacePrior(mean=0., variance=2.)
+        log_at_mean = float(prior(0., log=True))
+        log_off_mean = float(prior(3., log=True))
+        self.assertGreater(log_at_mean, log_off_mean)
+
+
+class TestDeltaPrior(unittest.TestCase):
+    """Tests for DeltaPrior"""
+
+    def test_delta_prior_creation(self):
+        """DeltaPrior can be created without arguments"""
+        prior = DeltaPrior()
+        self.assertIsNotNone(prior)
+
+    def test_delta_prior_name(self):
+        """DeltaPrior has correct name"""
+        prior = DeltaPrior()
+        self.assertEqual(prior.name, 'Delta')
+
+
+class TestStudentsTPrior(unittest.TestCase):
+    """Tests for StudentsTPrior
+
+    NOTE: StudentsTPrior._initialize() calls scipy.special.gammaln on a
+    CasADi symbolic variable, which raises a TypeError. This is a known bug
+    in the library. Tests below document this behaviour.
+    """
+
+    def test_students_t_prior_creation_raises_bug(self):
+        """StudentsTPrior creation raises TypeError due to scipy/CasADi incompatibility (known bug)"""
+        with self.assertRaises(TypeError):
+            StudentsTPrior(mean=0., variance=1., nu=3.)
+
+    def test_prior_students_t_factory_raises_bug(self):
+        """Prior.students_t() raises TypeError due to the same known bug"""
+        with self.assertRaises(TypeError):
+            Prior.students_t(mean=0., variance=1., nu=3.)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Bug: QuadraticProgram.setup() raised RuntimeError for quadratic objectives because it inherited LP's linearity check verbatim.
Root cause: QuadraticProgram inherited LinearProgram.setup() which calls _check_linearity() and rejects non-linear objectives. The inherited default solver clp also only handles linear problems.
Fix: Override QuadraticProgram.__init__ (default solver → osqp) and setup() (skip linearity check, call Optimizer.setup directly). Tests now verify 0.5*(x²+y²) sets up and solves to (0,0).